### PR TITLE
docs: Correct API permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If you are generating a specific API key for this tool, ensure it has the follow
 - `album.create`
 - `album.read`
 - `album.update`
+- `albumAsset.create`
 - `user.read`
 
 Alternatively, you can use a key with "All" permissions.


### PR DESCRIPTION
## What
Update the readme to state `albumAsset.create` is a required API permission.

## Why
Without this permission I got the following error:
```
time=08:17:53 msg="Error adding assets to album" error="API error: 403 Forbidden - {\"message\":\"Missing required permission: albumAsset.create\",\"error\":\"Forbidden\",\"statusCode\":403,\"correlationId\":\"l1iv4z6a\"}"
```