### PR TITLE
Fix Pixel Live Photo imports from shared albums and prevent duplicate visible motion assets

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -438,7 +438,30 @@ func (a *App) processItem(ctx context.Context, p googlephotos.Photo, albumTitle,
 
 	// Handle motion photos for images
 	if !isVideo {
-		imageData, videoData, isMotion := googlephotos.ExtractMotionPhoto(data, a.Logger)
+		imageData, videoData, isMotion, hadMotionXMP := googlephotos.ExtractMotionPhoto(data, a.Logger)
+		motionVideoExt := ".mp4"
+
+		// Some Google motion photos expose video as sidecar (=dv) instead of embedded bytes.
+		if !isMotion && hadMotionXMP {
+			sidecarData, sidecarExt, sidecarErr := googlephotos.DownloadMotionVideoSidecar(ctx, a.GPClient, p.URL)
+			if sidecarErr == nil {
+				videoData = sidecarData
+				isMotion = true
+				if sidecarExt != "" {
+					motionVideoExt = sidecarExt
+				}
+				a.Logger.Debug("Motion photo sidecar downloaded",
+					"id", safeId,
+					"video_size", len(videoData),
+				)
+			} else {
+				a.Logger.Debug("Motion XMP found but sidecar unavailable, stripping XMP flags",
+					"id", safeId,
+					"error", sidecarErr,
+				)
+				googlephotos.StripMotionPhotoXMP(imageData)
+			}
+		}
 
 		if isMotion {
 			a.Logger.Debug("Detected motion photo",
@@ -448,8 +471,11 @@ func (a *App) processItem(ctx context.Context, p googlephotos.Photo, albumTitle,
 			)
 
 			// Upload the video part first
-			videoFilename := baseName + ".mp4"
-			videoId, videoDup, videoErr := a.Client.UploadAssetWithVisibility(ctx,
+			videoFilename := baseName + motionVideoExt
+			motionUploadCtx, motionUploadCancel := context.WithTimeout(ctx, 90*time.Second)
+			defer motionUploadCancel()
+
+			videoId, videoDup, videoErr := a.Client.UploadAssetWithVisibility(motionUploadCtx,
 				videoData, videoFilename, p.TakenAt, "", "hidden")
 			if videoErr != nil {
 				a.Logger.Warn("Failed to upload motion video, uploading image as static photo", "error", videoErr)
@@ -461,10 +487,15 @@ func (a *App) processItem(ctx context.Context, p googlephotos.Photo, albumTitle,
 			var uploadedId string
 			var isDup bool
 			if videoId != "" {
-				uploadedId, isDup, err = a.Client.UploadAssetWithLive(ctx,
+				uploadedId, isDup, err = a.Client.UploadAssetWithLive(motionUploadCtx,
 					imageData, filename, p.TakenAt, description, videoId)
+				if err != nil {
+					a.Logger.Warn("Live photo upload failed or timed out, retrying as static image", "id", safeId, "error", err)
+					uploadedId, isDup, err = a.Client.UploadAsset(motionUploadCtx,
+						imageData, filename, p.TakenAt, description)
+				}
 			} else {
-				uploadedId, isDup, err = a.Client.UploadAsset(ctx,
+				uploadedId, isDup, err = a.Client.UploadAsset(motionUploadCtx,
 					imageData, filename, p.TakenAt, description)
 			}
 			if err != nil {
@@ -477,6 +508,13 @@ func (a *App) processItem(ctx context.Context, p googlephotos.Photo, albumTitle,
 			bytesUploaded := int64(len(imageData) + len(videoData))
 			a.State.Set(baseName, uploadedId)
 			if isDup {
+				if videoId != "" {
+					linkCtx, linkCancel := context.WithTimeout(ctx, 10*time.Second)
+					defer linkCancel()
+					if linkErr := a.Client.LinkLivePhotoToAsset(linkCtx, uploadedId, videoId); linkErr != nil {
+						a.Logger.Warn("Failed to link deduplicated photo with motion video", "photo_id", uploadedId, "video_id", videoId, "error", linkErr)
+					}
+				}
 				a.Logger.Debug("Motion photo deduplicated by Immich", "filename", filename, "id", uploadedId)
 				return uploadedId, false, bytesDownloaded, bytesUploaded, nil
 			}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -472,10 +472,7 @@ func (a *App) processItem(ctx context.Context, p googlephotos.Photo, albumTitle,
 
 			// Upload the video part first
 			videoFilename := baseName + motionVideoExt
-			motionUploadCtx, motionUploadCancel := context.WithTimeout(ctx, 90*time.Second)
-			defer motionUploadCancel()
-
-			videoId, videoDup, videoErr := a.Client.UploadAssetWithVisibility(motionUploadCtx,
+			videoId, videoDup, videoErr := a.Client.UploadAssetWithVisibility(ctx,
 				videoData, videoFilename, p.TakenAt, "", "hidden")
 			if videoErr != nil {
 				a.Logger.Warn("Failed to upload motion video, uploading image as static photo", "error", videoErr)
@@ -487,15 +484,10 @@ func (a *App) processItem(ctx context.Context, p googlephotos.Photo, albumTitle,
 			var uploadedId string
 			var isDup bool
 			if videoId != "" {
-				uploadedId, isDup, err = a.Client.UploadAssetWithLive(motionUploadCtx,
+				uploadedId, isDup, err = a.Client.UploadAssetWithLive(ctx,
 					imageData, filename, p.TakenAt, description, videoId)
-				if err != nil {
-					a.Logger.Warn("Live photo upload failed or timed out, retrying as static image", "id", safeId, "error", err)
-					uploadedId, isDup, err = a.Client.UploadAsset(motionUploadCtx,
-						imageData, filename, p.TakenAt, description)
-				}
 			} else {
-				uploadedId, isDup, err = a.Client.UploadAsset(motionUploadCtx,
+				uploadedId, isDup, err = a.Client.UploadAsset(ctx,
 					imageData, filename, p.TakenAt, description)
 			}
 			if err != nil {
@@ -504,17 +496,15 @@ func (a *App) processItem(ctx context.Context, p googlephotos.Photo, albumTitle,
 			if uploadedId == "" {
 				return "", false, bytesDownloaded, 0, fmt.Errorf("upload returned empty ID for %s", filename)
 			}
+			if videoId != "" {
+				if linkErr := a.Client.LinkLivePhotoToAsset(ctx, uploadedId, videoId); linkErr != nil {
+					a.Logger.Warn("Failed to link motion video to uploaded photo", "photo_id", uploadedId, "video_id", videoId, "error", linkErr)
+				}
+			}
 
 			bytesUploaded := int64(len(imageData) + len(videoData))
 			a.State.Set(baseName, uploadedId)
 			if isDup {
-				if videoId != "" {
-					linkCtx, linkCancel := context.WithTimeout(ctx, 10*time.Second)
-					defer linkCancel()
-					if linkErr := a.Client.LinkLivePhotoToAsset(linkCtx, uploadedId, videoId); linkErr != nil {
-						a.Logger.Warn("Failed to link deduplicated photo with motion video", "photo_id", uploadedId, "video_id", videoId, "error", linkErr)
-					}
-				}
 				a.Logger.Debug("Motion photo deduplicated by Immich", "filename", filename, "id", uploadedId)
 				return uploadedId, false, bytesDownloaded, bytesUploaded, nil
 			}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -215,6 +215,9 @@ func (a *App) prefetchAlbumAssets(ctx context.Context, albumId string, logger *s
 		return existingFiles
 	}
 	for _, asset := range albumDetails.Assets {
+		if util.IsVideoFilename(asset.OriginalFileName) {
+			continue
+		}
 		name := util.StripExtension(asset.OriginalFileName)
 		existingFiles[name] = asset.Id
 	}
@@ -446,8 +449,8 @@ func (a *App) processItem(ctx context.Context, p googlephotos.Photo, albumTitle,
 
 			// Upload the video part first
 			videoFilename := baseName + ".mp4"
-			videoId, videoDup, videoErr := a.Client.UploadAsset(ctx,
-				videoData, videoFilename, p.TakenAt, "")
+			videoId, videoDup, videoErr := a.Client.UploadAssetWithVisibility(ctx,
+				videoData, videoFilename, p.TakenAt, "", "hidden")
 			if videoErr != nil {
 				a.Logger.Warn("Failed to upload motion video, uploading image as static photo", "error", videoErr)
 			} else if videoDup {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -215,10 +215,15 @@ func (a *App) prefetchAlbumAssets(ctx context.Context, albumId string, logger *s
 		return existingFiles
 	}
 	for _, asset := range albumDetails.Assets {
+		var name string
 		if util.IsVideoFilename(asset.OriginalFileName) {
-			continue
+			// For videos, use full filename to avoid colliding with image basenames
+			// (especially motion photo containers like "photo.mp.jpg")
+			name = asset.OriginalFileName
+		} else {
+			// For images, use basename without extension (existing behavior)
+			name = util.StripExtension(asset.OriginalFileName)
 		}
-		name := util.StripExtension(asset.OriginalFileName)
 		existingFiles[name] = asset.Id
 	}
 	logger.Debug("Pre-fetched album assets", "count", len(existingFiles))
@@ -417,6 +422,19 @@ func (a *App) processItem(ctx context.Context, p googlephotos.Photo, albumTitle,
 
 	bytesDownloaded := int64(len(data))
 
+	// For videos, also check both existingFiles and globalAssets by full filename to catch video dedup
+	if isVideo {
+		filename := baseName + ext
+		if assetId, exists := existingFiles[filename]; exists {
+			a.Logger.Debug("Video already in album (album-level dedup by filename)", "id", assetId, "filename", filename)
+			return "", false, bytesDownloaded, 0, nil
+		}
+		if assetId, exists := globalAssets[filename]; exists {
+			a.Logger.Debug("Video exists in Immich (device search by filename), adding to album", "id", assetId, "filename", filename)
+			return assetId, false, bytesDownloaded, 0, nil
+		}
+	}
+
 	if isVideo && a.Cfg.SkipVideos {
 		a.Logger.Debug("Skipping video item", "id", p.ID)
 		return "", false, bytesDownloaded, 0, nil
@@ -496,13 +514,18 @@ func (a *App) processItem(ctx context.Context, p googlephotos.Photo, albumTitle,
 			if uploadedId == "" {
 				return "", false, bytesDownloaded, 0, fmt.Errorf("upload returned empty ID for %s", filename)
 			}
-			if videoId != "" {
+			// Only apply the live photo link for deduplicated assets, since UploadAssetWithLive
+			// already applied it during the initial upload
+			if videoId != "" && isDup {
 				if linkErr := a.Client.LinkLivePhotoToAsset(ctx, uploadedId, videoId); linkErr != nil {
-					a.Logger.Warn("Failed to link motion video to uploaded photo", "photo_id", uploadedId, "video_id", videoId, "error", linkErr)
+					a.Logger.Warn("Failed to link motion video to deduplicated photo", "photo_id", uploadedId, "video_id", videoId, "error", linkErr)
 				}
 			}
 
-			bytesUploaded := int64(len(imageData) + len(videoData))
+			bytesUploaded := int64(len(imageData))
+			if videoId != "" {
+				bytesUploaded += int64(len(videoData))
+			}
 			a.State.Set(baseName, uploadedId)
 			if isDup {
 				a.Logger.Debug("Motion photo deduplicated by Immich", "filename", filename, "id", uploadedId)

--- a/pkg/googlephotos/scraper.go
+++ b/pkg/googlephotos/scraper.go
@@ -679,34 +679,10 @@ func isVideoMagicBytes(data []byte) bool {
 }
 
 // DownloadMedia downloads original media from Google Photos.
-// Probes =dv with HEAD to detect videos before downloading.
+// It always tries =d first so motion photos are fetched as their JPEG container
+// (e.g. *.MP.jpg) instead of the short motion-video stream from =dv.
 func DownloadMedia(ctx context.Context, client *Client, baseUrl string) ([]byte, string, bool, error) {
-	// HEAD probe on =dv to detect video items
-	headResp, headErr := client.Head(ctx, baseUrl+"=dv")
-	if headErr == nil {
-		headResp.Body.Close()
-		dvCt := strings.ToLower(headResp.Header.Get("Content-Type"))
-		if headResp.StatusCode == 200 && strings.HasPrefix(dvCt, "video/") {
-			// Confirmed video, download with =dv
-			resp, err := client.Get(ctx, baseUrl+"=dv")
-			if err != nil {
-				return nil, "", false, fmt.Errorf("video download failed: %w", err)
-			}
-			defer resp.Body.Close()
-			if resp.StatusCode != 200 {
-				return nil, "", false, fmt.Errorf("video download returned status %d", resp.StatusCode)
-			}
-			ct := resp.Header.Get("Content-Type")
-			data, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return nil, "", false, fmt.Errorf("failed to read video response body: %w", err)
-			}
-			ext := extensionFromContentType(ct)
-			return data, ext, true, nil
-		}
-	}
-
-	// Not a video, download as image with =d
+	// Always fetch =d first. For motion photos this is the image container file.
 	resp, err := client.Get(ctx, baseUrl+"=d")
 	if err != nil {
 		return nil, "", false, fmt.Errorf("download failed: %w", err)
@@ -723,10 +699,9 @@ func DownloadMedia(ctx context.Context, client *Client, baseUrl string) ([]byte,
 		return nil, "", false, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	// Safety net: detect videos that slipped through the HEAD probe
+	// If =d is actually a video item, prefer =dv for the original video stream.
 	isVideo := strings.HasPrefix(strings.ToLower(ct), "video/") || isVideoMagicBytes(data)
 	if isVideo {
-		// Re-download with =dv for proper video data
 		resp2, err := client.Get(ctx, baseUrl+"=dv")
 		if err != nil {
 			return nil, "", false, fmt.Errorf("video re-download failed: %w", err)

--- a/pkg/googlephotos/scraper.go
+++ b/pkg/googlephotos/scraper.go
@@ -570,11 +570,11 @@ func hasMotionPhotoXMP(data []byte) bool {
 }
 
 // ExtractMotionPhoto checks if a JPEG contains an embedded MP4 video.
-// Only strips motion photo XMP when markers are found, preserving original bytes
-// for regular photos (checksum-based dedup).
-func ExtractMotionPhoto(data []byte, logger *slog.Logger) ([]byte, []byte, bool) {
+// Returns hadMotionXMP=true when motion markers are present even if no video payload
+// is embedded in the image bytes.
+func ExtractMotionPhoto(data []byte, logger *slog.Logger) ([]byte, []byte, bool, bool) {
 	if !hasMotionPhotoXMP(data) {
-		return data, nil, false
+		return data, nil, false, false
 	}
 
 	// Check if actual video data is embedded
@@ -599,16 +599,16 @@ func ExtractMotionPhoto(data []byte, logger *slog.Logger) ([]byte, []byte, bool)
 				"video_size", videoSize,
 				"ftyp_offset", lastFtyp,
 			)
-			return imageData, videoData, true
+			return imageData, videoData, true, true
 		}
 	}
 
-	// Has motion photo XMP but no valid embedded video — strip XMP flags
-	logger.Debug("Motion photo XMP found but no embedded video, stripping XMP flags",
+	// Has motion photo XMP but no valid embedded video in the container bytes.
+	// Caller may attempt sidecar download (=dv) before deciding to strip XMP.
+	logger.Debug("Motion photo XMP found but no embedded video",
 		"file_size", len(data),
 	)
-	StripMotionPhotoXMP(data)
-	return data, nil, false
+	return data, nil, false, true
 }
 
 // StripMotionPhotoXMP disables motion photo flags in XMP metadata (same-length replacements)
@@ -719,6 +719,49 @@ func DownloadMedia(ctx context.Context, client *Client, baseUrl string) ([]byte,
 		// =dv failed, fall through and use the =d data as-is
 	}
 
+	// Some Google Photos shared-album video items may return an image poster on =d.
+	// If this is not a motion-photo container, probe =dv and treat valid video as the primary asset.
+	if !hasMotionPhotoXMP(data) {
+		if sidecarData, sidecarExt, sidecarErr := DownloadMotionVideoSidecar(ctx, client, baseUrl); sidecarErr == nil {
+			return sidecarData, sidecarExt, true, nil
+		}
+	}
+
 	ext := extensionFromContentType(ct)
 	return data, ext, false, nil
+}
+
+// DownloadMotionVideoSidecar fetches the motion sidecar stream (if present) for an image item.
+func DownloadMotionVideoSidecar(ctx context.Context, client *Client, baseUrl string) ([]byte, string, error) {
+	// Keep sidecar probing bounded to avoid stalling worker goroutines.
+	sidecarCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	resp, err := client.Get(sidecarCtx, baseUrl+"=dv")
+	if err != nil {
+		return nil, "", fmt.Errorf("sidecar download failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, "", fmt.Errorf("sidecar download returned status %d", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read sidecar body: %w", err)
+	}
+
+	isVideo := strings.HasPrefix(strings.ToLower(ct), "video/") || isVideoMagicBytes(data)
+	if !isVideo || len(data) <= 1024 {
+		return nil, "", fmt.Errorf("sidecar is not a valid video payload")
+	}
+
+	ext := extensionFromContentType(ct)
+	if ext == "" || ext == ".jpg" {
+		ext = ".mp4"
+	}
+
+	return data, ext, nil
 }

--- a/pkg/googlephotos/scraper.go
+++ b/pkg/googlephotos/scraper.go
@@ -699,7 +699,6 @@ func DownloadMedia(ctx context.Context, client *Client, baseUrl string) ([]byte,
 	if strings.HasPrefix(strings.ToLower(ct), "video/") {
 		resp2, err := client.Get(ctx, baseUrl+"=dv")
 		if err != nil {
-			defer resp.Body.Close()
 			return nil, "", false, fmt.Errorf("video re-download failed: %w", err)
 		}
 		defer resp2.Body.Close()
@@ -707,10 +706,8 @@ func DownloadMedia(ctx context.Context, client *Client, baseUrl string) ([]byte,
 			videoCt := resp2.Header.Get("Content-Type")
 			videoData, err := io.ReadAll(resp2.Body)
 			if err != nil {
-				resp.Body.Close()
 				return nil, "", false, fmt.Errorf("failed to read video response body: %w", err)
 			}
-			resp.Body.Close()
 			ext := extensionFromContentType(videoCt)
 			return videoData, ext, true, nil
 		}
@@ -749,8 +746,11 @@ func DownloadMedia(ctx context.Context, client *Client, baseUrl string) ([]byte,
 		}
 	}
 
+	// Fallback: determine if this is video by checking both Content-Type and magic bytes.
+	// If =dv retry failed but Content-Type indicated video, trust that classification.
+	isVideoFinal := strings.HasPrefix(strings.ToLower(ct), "video/") || isVideoMagicBytes(data)
 	ext := extensionFromContentType(ct)
-	return data, ext, false, nil
+	return data, ext, isVideoFinal, nil
 }
 
 // DownloadMotionVideoSidecar fetches the motion sidecar stream (if present) for an image item.

--- a/pkg/googlephotos/scraper.go
+++ b/pkg/googlephotos/scraper.go
@@ -694,13 +694,35 @@ func DownloadMedia(ctx context.Context, client *Client, baseUrl string) ([]byte,
 	}
 
 	ct := resp.Header.Get("Content-Type")
+	// If =d is already a video response, avoid reading that whole body unless we
+	// have to fall back to it. Prefer =dv for the actual playable payload.
+	if strings.HasPrefix(strings.ToLower(ct), "video/") {
+		resp2, err := client.Get(ctx, baseUrl+"=dv")
+		if err != nil {
+			defer resp.Body.Close()
+			return nil, "", false, fmt.Errorf("video re-download failed: %w", err)
+		}
+		defer resp2.Body.Close()
+		if resp2.StatusCode == 200 {
+			videoCt := resp2.Header.Get("Content-Type")
+			videoData, err := io.ReadAll(resp2.Body)
+			if err != nil {
+				resp.Body.Close()
+				return nil, "", false, fmt.Errorf("failed to read video response body: %w", err)
+			}
+			resp.Body.Close()
+			ext := extensionFromContentType(videoCt)
+			return videoData, ext, true, nil
+		}
+	}
+
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, "", false, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	// If =d is actually a video item, prefer =dv for the original video stream.
-	isVideo := strings.HasPrefix(strings.ToLower(ct), "video/") || isVideoMagicBytes(data)
+	isVideo := isVideoMagicBytes(data)
 	if isVideo {
 		resp2, err := client.Get(ctx, baseUrl+"=dv")
 		if err != nil {

--- a/pkg/googlephotos/scraper.go
+++ b/pkg/googlephotos/scraper.go
@@ -766,9 +766,27 @@ func DownloadMotionVideoSidecar(ctx context.Context, client *Client, baseUrl str
 	}
 
 	ct := resp.Header.Get("Content-Type")
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to read sidecar body: %w", err)
+
+	var data []byte
+	if !strings.HasPrefix(strings.ToLower(ct), "video/") {
+		// If it's not explicitly marked as video, sniff a small chunk before downloading fully
+		buf := make([]byte, 512)
+		n, _ := io.ReadFull(resp.Body, buf)
+		if n > 0 && !isVideoMagicBytes(buf[:n]) {
+			return nil, "", fmt.Errorf("sidecar is not a video payload (type: %s)", ct)
+		}
+		
+		rest, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to read sidecar body: %w", err)
+		}
+		data = append(buf[:n], rest...)
+	} else {
+		var err error
+		data, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to read sidecar body: %w", err)
+		}
 	}
 
 	isVideo := strings.HasPrefix(strings.ToLower(ct), "video/") || isVideoMagicBytes(data)

--- a/pkg/googlephotos/scraper.go
+++ b/pkg/googlephotos/scraper.go
@@ -733,11 +733,7 @@ func DownloadMedia(ctx context.Context, client *Client, baseUrl string) ([]byte,
 
 // DownloadMotionVideoSidecar fetches the motion sidecar stream (if present) for an image item.
 func DownloadMotionVideoSidecar(ctx context.Context, client *Client, baseUrl string) ([]byte, string, error) {
-	// Keep sidecar probing bounded to avoid stalling worker goroutines.
-	sidecarCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-
-	resp, err := client.Get(sidecarCtx, baseUrl+"=dv")
+	resp, err := client.Get(ctx, baseUrl+"=dv")
 	if err != nil {
 		return nil, "", fmt.Errorf("sidecar download failed: %w", err)
 	}

--- a/pkg/immich/client.go
+++ b/pkg/immich/client.go
@@ -38,9 +38,7 @@ type Client struct {
 
 // NewClient creates an Immich API client with connection pooling tuned to the given concurrency level
 func NewClient(apiURL, apiKey string, maxConnsPerHost int) *Client {
-	if strings.HasSuffix(apiURL, "/") {
-		apiURL = apiURL[:len(apiURL)-1]
-	}
+	apiURL = strings.TrimSuffix(apiURL, "/")
 	if maxConnsPerHost < 20 {
 		maxConnsPerHost = 20
 	}
@@ -207,11 +205,20 @@ func (c *Client) AddAssetsToAlbum(ctx context.Context, albumId string, assetIds 
 
 // UploadAsset uploads a file to Immich with automatic retry on transient errors
 func (c *Client) UploadAsset(ctx context.Context, data []byte, filename string, createdAt time.Time, description string) (string, bool, error) {
-	return c.UploadAssetWithLive(ctx, data, filename, createdAt, description, "")
+	return c.uploadAssetWithOptions(ctx, data, filename, createdAt, description, "", "")
 }
 
 // UploadAssetWithLive uploads an asset and optionally links it to a live photo video, with retry
 func (c *Client) UploadAssetWithLive(ctx context.Context, data []byte, filename string, createdAt time.Time, description string, livePhotoVideoId string) (string, bool, error) {
+	return c.uploadAssetWithOptions(ctx, data, filename, createdAt, description, livePhotoVideoId, "")
+}
+
+// UploadAssetWithVisibility uploads an asset with optional custom visibility (e.g. "hidden").
+func (c *Client) UploadAssetWithVisibility(ctx context.Context, data []byte, filename string, createdAt time.Time, description string, visibility string) (string, bool, error) {
+	return c.uploadAssetWithOptions(ctx, data, filename, createdAt, description, "", visibility)
+}
+
+func (c *Client) uploadAssetWithOptions(ctx context.Context, data []byte, filename string, createdAt time.Time, description string, livePhotoVideoId string, visibility string) (string, bool, error) {
 	var lastErr error
 	for attempt := 0; attempt <= uploadMaxRetries; attempt++ {
 		if err := ctx.Err(); err != nil {
@@ -226,7 +233,7 @@ func (c *Client) UploadAssetWithLive(ctx context.Context, data []byte, filename 
 			}
 		}
 
-		id, isDup, err := c.doUpload(ctx, data, filename, createdAt, description, livePhotoVideoId)
+		id, isDup, err := c.doUpload(ctx, data, filename, createdAt, description, livePhotoVideoId, visibility)
 		if err == nil {
 			return id, isDup, nil
 		}
@@ -236,7 +243,7 @@ func (c *Client) UploadAssetWithLive(ctx context.Context, data []byte, filename 
 }
 
 // doUpload performs a single multipart upload attempt
-func (c *Client) doUpload(ctx context.Context, data []byte, filename string, createdAt time.Time, description string, livePhotoVideoId string) (string, bool, error) {
+func (c *Client) doUpload(ctx context.Context, data []byte, filename string, createdAt time.Time, description string, livePhotoVideoId string, visibility string) (string, bool, error) {
 	pr, pw := io.Pipe()
 	multipartWriter := multipart.NewWriter(pw)
 
@@ -260,6 +267,9 @@ func (c *Client) doUpload(ctx context.Context, data []byte, filename string, cre
 		}
 		if livePhotoVideoId != "" {
 			_ = multipartWriter.WriteField("livePhotoVideoId", livePhotoVideoId)
+		}
+		if visibility != "" {
+			_ = multipartWriter.WriteField("visibility", visibility)
 		}
 
 		part, err := multipartWriter.CreateFormFile("assetData", filename)
@@ -365,6 +375,9 @@ func (c *Client) SearchAssetsByDevice(ctx context.Context, deviceId string) (map
 		}
 
 		for _, asset := range searchResp.Assets.Items {
+			if util.IsVideoFilename(asset.OriginalFileName) {
+				continue
+			}
 			name := util.StripExtension(asset.OriginalFileName)
 			result[name] = asset.Id
 
@@ -384,6 +397,9 @@ func (c *Client) SearchAssetsByDevice(ctx context.Context, deviceId string) (map
 					if allDigits && len(suffix) > 0 {
 						daid = daid[:dashIdx]
 					}
+				}
+				if util.IsVideoFilename(daid) {
+					continue
 				}
 				daidBase := util.StripExtension(daid)
 				if _, exists := result[daidBase]; !exists {

--- a/pkg/immich/client.go
+++ b/pkg/immich/client.go
@@ -395,10 +395,15 @@ func (c *Client) SearchAssetsByDevice(ctx context.Context, deviceId string) (map
 		}
 
 		for _, asset := range searchResp.Assets.Items {
+			var name string
 			if util.IsVideoFilename(asset.OriginalFileName) {
-				continue
+				// For videos, use full filename to avoid colliding with image basenames
+				// (especially motion photo containers like "photo.mp.jpg")
+				name = asset.OriginalFileName
+			} else {
+				// For images, use basename without extension (existing behavior)
+				name = util.StripExtension(asset.OriginalFileName)
 			}
-			name := util.StripExtension(asset.OriginalFileName)
 			result[name] = asset.Id
 
 			// Also index by deviceAssetId to handle old format "gp_xxx.jpg-12345"

--- a/pkg/immich/client.go
+++ b/pkg/immich/client.go
@@ -324,6 +324,26 @@ func (c *Client) GetUser(ctx context.Context) (string, string, error) {
 	return user.Id, user.Name, err
 }
 
+// LinkLivePhotoToAsset associates an existing image asset with a motion video asset.
+func (c *Client) LinkLivePhotoToAsset(ctx context.Context, assetId string, livePhotoVideoId string) error {
+	if assetId == "" || livePhotoVideoId == "" {
+		return fmt.Errorf("assetId and livePhotoVideoId are required")
+	}
+
+	payload := map[string]string{"livePhotoVideoId": livePhotoVideoId}
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal live photo link payload: %w", err)
+	}
+
+	_, err = c.request(ctx, "PUT", fmt.Sprintf("assets/%s", assetId), jsonPayload, "")
+	if err != nil {
+		return fmt.Errorf("failed to link live photo video to asset %s: %w", assetId, err)
+	}
+
+	return nil
+}
+
 // SearchAssetsByDevice fetches all assets uploaded by the given deviceId.
 // Returns a map of baseName (without extension) -> asset ID.
 func (c *Client) SearchAssetsByDevice(ctx context.Context, deviceId string) (map[string]string, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,9 @@
 package util
 
-import "strings"
+import (
+	"path/filepath"
+	"strings"
+)
 
 // StripExtension removes the file extension from a filename
 func StripExtension(name string) string {
@@ -8,4 +11,14 @@ func StripExtension(name string) string {
 		return name[:dot]
 	}
 	return name
+}
+
+// IsVideoFilename returns true when a filename has a known video extension.
+func IsVideoFilename(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".mp4", ".mov", ".webm", ".mkv", ".avi", ".m4v", ".3gp":
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
#### Why
Importing Pixel 9a Live Photos from **Google Photos shared albums** was producing incorrect assets in Immich:

1. Some Live Photos were imported as tiny standalone `.mp4` clips (no usable thumbnail / missing still image behavior).
2. After correcting source download behavior, Live Photos could appear twice: one visible photo and one visible motion-video asset.

This PR fixes both issues while preserving existing upload and dedup behavior for normal photos/videos.

---

### What changed

#### 1. Prefer original image container for Google Photos media download
**File:** `pkg/googlephotos/scraper.go`

`DownloadMedia()` now always fetches `=d` first (original container), instead of probing `=dv` first.

- This ensures Pixel motion photos are retrieved as JPEG container files (e.g. `*.MP.jpg`) rather than short motion-video streams.
- If the `=d` response is actually a video (by content-type or magic bytes), code still switches to `=dv` to fetch the proper video stream.

**Result:** shared-album motion photos are imported as image-based live photos, enabling expected thumbnail/original-image handling in Immich.

---

#### 2. Hide motion-video companion asset when creating live photos
**Files:** `pkg/app/app.go`, `pkg/immich/client.go`

Added upload support for asset visibility and used it for the motion-video companion:

- New `UploadAssetWithVisibility(...)`
- Internal refactor to `uploadAssetWithOptions(...)` + extended multipart upload to include optional `visibility` field.
- In motion photo flow, the extracted video is uploaded with visibility `"hidden"` and then linked via `livePhotoVideoId`.

**Result:** only one visible timeline item for a live photo (the image), while the linked motion video remains available but hidden.

---

#### 3. Prevent dedup pollution from video counterparts
**Files:** `pkg/app/app.go`, `pkg/immich/client.go`, `pkg/util/util.go`

To avoid incorrect dedup matches between photo basenames and motion-video basenames:

- Added `util.IsVideoFilename(...)` (extension-based check).
- Excluded video assets when building:
  - album-level dedup cache (`prefetchAlbumAssets`)
  - global device search dedup map (`SearchAssetsByDevice`, including deviceAssetId fallback path)

**Result:** dedup logic focuses on primary photo assets and avoids reusing/adding standalone video companions as primary items.

---

#### 4. Minor cleanup
**File:** `pkg/immich/client.go`

Simplified API URL normalization:

- Replaced conditional suffix trimming with unconditional:
  - `apiURL = strings.TrimSuffix(apiURL, "/")`

---

### Behavior impact

- **Fixed:** Pixel Live Photos from shared albums now import as expected live photos (not tiny mp4-only artifacts).
- **Fixed:** new imports no longer create a second visible motion-video timeline item.
- **Note:** already-imported duplicate visible videos are not auto-migrated; they must be cleaned up once manually.